### PR TITLE
Update 2021-01-05-using-python-to-bash.md: add missing venv activate

### DIFF
--- a/_posts/2021-01-05-using-python-to-bash.md
+++ b/_posts/2021-01-05-using-python-to-bash.md
@@ -54,6 +54,7 @@ $ cat revenv.sh
 deactivate
 rm -rf venv
 python3 -mvenv venv
+source venv/bin/activate
 pip install --upgrade pip
 pip install wheel
 pip install -r requirements.txt


### PR DESCRIPTION
add the missing `source venv/bin/activate` to the revenv.sh script