### PR TITLE
Fix hero image scaling

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -23,7 +23,7 @@ header {
   align-items: center;
   background-color: rgba(0,0,0,0.3);
   overflow: hidden;
-  place-content: center;
+  padding: 0 !important;
 }
 
 img {
@@ -38,12 +38,11 @@ header > * {
 }
 
 header img {
-  max-height: 50vh;
   object-fit: cover;
   object-position: center;
   z-index: -1;
-  max-width: 100vw;
-  width: 100vw;
+  width: 100%;
+  height: 100%;
   padding: 0;
 }
 


### PR DESCRIPTION
This fixes the hero image scaling in the background of page
titles, etc.

(I had accidentally set a `position-content: center` on the parent
<header>).