### PR TITLE
Fix share and next/prev rows overflowing container

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -40,7 +40,7 @@
       </div>
     </div>
 
-    <div class='row justify-content-center mb-3'>
+    <div class='row justify-content-center mb-3 mx-0'>
       <div class='col-lg-8 text-center'>
         <span class='letter-spacing-01 text-uppercase text-secondary me-2'>Share</span>
         <a href='https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}' target='_blank'>
@@ -52,7 +52,7 @@
       </div>
     </div>
 
-    <div class='row justify-content-center mb-5 pt-5 border-top'>
+    <div class='row justify-content-center mb-5 pt-5 border-top mx-0'>
       <div class='col-lg-4 text-center text-lg-start'>
         {{ with .NextInSection }} 
           <div>


### PR DESCRIPTION
These two rows were causing a slight oversize in width and I
hate spurious horizontal scrollbars.  So I had to fix this... :)