### PR TITLE
Fix for header title centering on chrome

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -16,6 +16,9 @@ body {
   font-size: 1.25rem;
 }
 
+/* Note: if you try to add a `height` value here
+  don't forget to match the `max-height`
+  of the `header img` below */
 header {
   display: grid;
   grid-template-areas: "hero";

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -19,7 +19,6 @@ body {
 header {
   display: grid;
   grid-template-areas: "hero";
-  height: 25vh;
   align-items: center;
   background-color: rgba(0,0,0,0.3);
   overflow: hidden;
@@ -30,8 +29,6 @@ img {
   max-width: 100%;
   padding: 0 9%;
 }
-
-
 
 header > * {
   grid-area: hero;
@@ -44,6 +41,11 @@ header img {
   width: 100%;
   height: 100%;
   padding: 0;
+}
+
+/* This controls the height of the title hero banner */
+header, header img {
+  max-height: 25vh;
 }
 
 header h1 {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,8 +5,8 @@
 <div class="page">
   <article class="{{ .Title | urlize }}-page">
     <div class='row  justify-content-center text-center my-4 mx-0'>
-      <header class="align-items-start">
-        <div class='col pt-5'>
+      <header>
+        <div class='col'>
           <h1 class="title mb-lg-4 text-white">
             {{ .Title | markdownify }}
           </h1>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,8 +5,8 @@
 <div class="page mb-4">
 
   <div class='row justify-content-center text-center my-4 mx-0'>
-    <header class="align-items-start" style='height: 20vh;'>
-      <div class='col pt-5'>
+    <header>
+      <div class='col'>
         <h1 class="title mb-lg-4 text-white">
           {{ .Title | markdownify }}
         </h1>


### PR DESCRIPTION
The `header` element and the `img` inside it need to have matching heights.
If you set the
```css
header {
...
height: 30vh;
...
}
```

You'll need to remember to set the `header img` rule to the same:
```css
header img {
...
max-height: 30vh;
...
}
```

I've set a rule for _both_ of them in this PR:
```css
/* This controls the height of the title hero banner */
header, header img {
  max-height: 25vh;
}
```