### PR TITLE
Add 'Source Sans Pro' fontstack

### DIFF
--- a/assets/sass/fonts.scss
+++ b/assets/sass/fonts.scss
@@ -1,0 +1,27 @@
+@font-face {
+  font-family: "Source Sans Pro";
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+  src: url('/assets/fonts/source-sans-pro/source-sans-pro-regular.woff2');
+}
+@font-face {
+  font-family: "Source Sans Pro";
+  font-weight: 400;
+  font-display: swap;
+  font-style: italic;
+  src: url('/assets/fonts/source-sans-pro/source-sans-pro-italic.woff2');
+}
+@font-face{
+  font-family: "Source Sans Pro";
+  font-weight: 500;
+  font-display: swap;
+  font-style: normal;
+  src: url('/assets/fonts/source-sans-pro/source-sans-pro-bold.woff2');
+}
+@font-face{
+  font-family: "Source Sans Pro";
+  font-weight: 500;
+  font-style: italic;
+  src: url('/assets/fonts/source-sans-pro/source-sans-pro-bold-italic.woff2');
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -1,6 +1,9 @@
 /* Override any bootstrap variables here before importing bootstrap itself */
 
+/* Matches color from old type-on-strap jekyll theme */
 $primary: #337ab7;
+
+$font-family-sans-serif: "Source Sans Pro", system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
 
 @for $i from 1 through 6 {
   h#{$i} a { color: black; text-decoration: none; }
@@ -11,6 +14,7 @@ $primary: #337ab7;
 
 /* Custom SASS imports */
 @import 'syntax';
+@import 'fonts';
 
 body {
   font-size: 1.25rem;


### PR DESCRIPTION
I'm using the 'Source Sans Pro' fonts already included in the
previous (jekyll) version of the site now.