### PR TITLE
Update page footer with correct feed URL

### DIFF
--- a/layouts/partials/page-footer.html
+++ b/layouts/partials/page-footer.html
@@ -6,7 +6,7 @@
     <div class='row text-primary mt-4'>
       <div class='col'>
 
-        <a href='/index.xml' title='Follow RSS feed' class='me-3 text-decoration-none'>
+        <a href='/feed.xml' title='Follow RSS feed' class='me-3 text-decoration-none'>
           <svg class='bi' height='2.5rem' width='2.5rem' fill='currentColor'><use xlink:href='/bootstrap-icons.svg#rss-fill'/></svg>
         </a>
 


### PR DESCRIPTION
With the recent changes to the blog, the feed URL seems to have changed from `/index.xml` to `/feed.xml` 