### PR TITLE
SQL Engineering Guidelines: Replace "faculty" with "factorial"

### DIFF
--- a/content/posts/2022-04-15-sql-engineering-guidelines.md
+++ b/content/posts/2022-04-15-sql-engineering-guidelines.md
@@ -150,7 +150,7 @@ Additionally, certain `WHERE id IN (...)` clauses begin to show degraded perform
 
 **Avoid `JOIN`-ing more than 10 tables at once.**
 
-If the optimizer were to brute-force all possible `JOIN` combinations on an `n`-way table `JOIN`, the number of combinations would be `n!` (n-th faculty).
+If the optimizer were to brute-force all possible `JOIN` combinations on an `n`-way table `JOIN`, the number of combinations would be `n!` ([factorial](https://en.wikipedia.org/wiki/Factorial) of n).
 This becomes an unwieldy number at a value of `n=10`.
 
 The optimizer will have to apply heuristics around a join-plan depth of 10, and do weird things, including sometimes missing obvious optimizations.


### PR DESCRIPTION
German "Fakultät" and Dutch "faculteit" may translate to "faculty", but in a mathematical context the English name of the function is "factorial".