### PR TITLE
Replace mysqldump with mysqlbinlog in first paragraph

### DIFF
--- a/content/posts/2022-06-07-mysql-binlog-compression-and-large-transactions.md
+++ b/content/posts/2022-06-07-mysql-binlog-compression-and-large-transactions.md
@@ -22,7 +22,7 @@ Replication stops with
 ```console
 Got fatal error 1236 from master when reading data from binary log: 'log event entry exceeded max_allowed_packet; Increase max_allowed_packet on master; the first event '' at 4, the last event read from '../log/binlog.002558' at 19959785, the last byte read from '../log/binlog.002558' at 19959804
 ```
-Trying to run `mysqldump -vvv ...` on the broken binlog fails and produces no output useful for diagnostics.
+Trying to run `mysqlbinlog -vvv ...` on the broken binlog fails and produces no output useful for diagnostics.
 
 # Using the flight recorder
 


### PR DESCRIPTION
Use mysqlbinlog instead of mysqldump as mentioned in the Problems and Solutions section.