### PR TITLE
fix mastodon link preview card links

### DIFF
--- a/layouts/partials/head-meta.html
+++ b/layouts/partials/head-meta.html
@@ -6,7 +6,7 @@
 
 <link rel="apple-touch-icon" href="icon.png"><!-- TODO: provide such an icon -->
 <link rel="favicon.ico" rel="icon" type="image/ico">
-<link rel="canonical" href="{{ .Site.BaseURL }}">
+<link rel="canonical" href="{{ .Permalink }}">
 
 <!-- Manually add RSS Feeds for full site, #mysql and #review -->
 <link rel="alternate" type="application/rss+xml" href='{{ "feed.xml" | absURL }}' title="{{ $.Site.Title }}">
@@ -29,7 +29,6 @@
 <meta name="description" content='{{ .Param "description" }}' />
 <meta property="og:description" content='{{ .Param "description" }}' />
 
-<link rel="canonical" href="{{ .Site.BaseURL }}" />
 <meta property="og:url" content="{{ .Site.BaseURL }}" />
 
 {{ if .Page.Date }}


### PR DESCRIPTION
Mastodon seems to use the `<link rel="canonical" href="">` element to get the URL the link preview card should point to. This should point to the permanent URL, also fix doubling of this element.