### PR TITLE
Add button to open GitHub edit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,10 @@ description: "Something old, something new, something borrowed, something blue"
 
 params:
   feature-img: "assets/img/background/rijksmuseum.jpg"
+  editPost:
+    URL: "https://github.com/isotopp/isotopp.github.io/edit/main/content"
+    appendFilePath: True
+    Text: "Suggest Changes"
 
 frontmatter:
   date: [":filename", ":default"]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -72,6 +72,19 @@
       </div>
     </div>
 
+    {{/* Option to edit the post */}}
+    {{/* ======================= */}}
+    {{ if or .Params.editPost.URL .Site.Params.editPost.URL }}
+    {{ $fileUrlPath := path.Join .File.Path }}
+    <div class='row justify-content-center py-3 mb-3 mx-0'>
+      <div class='col-lg-8 text-center'>
+        <a href="{{ .Params.editPost.URL | default .Site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( .Site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer" target="_blank">
+            <span class='letter-spacing-01 text-uppercase text-secondary me-2'>{{- .Params.editPost.Text | default (.Site.Params.editPost.Text | default (i18n "edit_post" | default "Edit")) -}}</span>
+        </a>
+      </div>
+    </div>
+    {{ end }}
+
     <div class='row justify-content-center mb-5 pt-5 border-top mx-0'>
       <div class='col-lg-4 text-center text-lg-start'>
         {{ with .NextInSection }}


### PR DESCRIPTION
To submit changes to a blog article, – without this patch – you need to find the repository, fork it, find the blog post change it and open a PR to the main repository. This takes some time and discourages small fixes like typos or small errors.

To address this, this patch adds a configurable edit button to the bottom of every article. In the current configuration, clicking this link will take you to the GitHub edit page for the article. If you did not fork the repository yet, you get a button to fork it and then get directly tossed into the editor to make changes. The changes can then easily be opened as a PR from the same webpage.

There are a few options that can be configured in the `editPost` parameter:
- `Text`: This is the text that will be displayed at the bottom of the article.
- `URL`: This will be the link the button leads to
- `appendFilePath`: If this is set to false, the target of the link will always be the same, e.g. only the repository's GitHub page. If it is set to true, the name of the article path will be appended.

These options enable flexibility should the repository ever move or if you would like to point to somewhere else, like the GitHub IDE. Removing `editPost` hash will disable the button entirely.