### PR TITLE
Update 2022-11-28-systemd-and-docker-fd.md

### DIFF
--- a/content/posts/2022-11-28-systemd-and-docker-fd.md
+++ b/content/posts/2022-11-28-systemd-and-docker-fd.md
@@ -111,6 +111,6 @@ updating /var/run/docker.sock tcp://0.0.0.0:2375 → /run/docker.sock tcp://0.0.
 please update the unit file accordingly.
 ```
 
-The second one adds a listener to port `[::1]:2375`.
+The second one adds a listener to port `[::]:2375`.
 
 And that will allow me to talk to the Docker server on my development host over the network.


### PR DESCRIPTION
listener is added to all IPs not just localhost/::1

```
     Listen: /run/docker.sock (Stream)
             [::]:2375 (Stream)
```