### PR TITLE
Fix math in Bandwidth, IOPS and Latency

### DIFF
--- a/content/posts/2022-11-07-bandwidth-iops-and-latency.md
+++ b/content/posts/2022-11-07-bandwidth-iops-and-latency.md
@@ -163,7 +163,7 @@ In MySQL, a commit is a multiple of 512 bytes, and a checkpoint write is a multi
 
 At 2500 writes per second (0.4ms write latency) we get 40 MB/s at 16 KB page write size (and hardly more than 1 MB/s for 512 byte commit writes). 
 
-At 20000 writes per second (0.04ms write latency) we get 400 MB/s at 16 KB page write size, and hardly more than 10 MB/s for 512 byte commit writes. 
+At 25000 writes per second (0.04ms write latency) we get 400 MB/s at 16 KB page write size, and hardly more than 10 MB/s for 512 byte commit writes. 
 
 The point of checkpointing is to coalesce updates to the same page, so it is usually a lot less checkpoint writes than commit writes: several updates to different rows on the same page are checkpointed together at a later time, saving write bandwidth.
 


### PR DESCRIPTION
Pretty sure the math is off here in one way or another (or I am missing something). I think you meant to use 25k here: 400MB / 16KB = 25 000 (writes) 

This is also more in line with the latency assuming for single-threaded load. You might also want to change the bandwidth value for 512byte writes, but  12MB/s is still hardly more than 10MB/s, depending on the definition of "hardly".

Alternatively the 20k are correct but latency and bandwidth are off.