### PR TITLE
Update 2023-05-06-50-years-in-filesystems-1984.md

### DIFF
--- a/content/posts/2023-05-06-50-years-in-filesystems-1984.md
+++ b/content/posts/2023-05-06-50-years-in-filesystems-1984.md
@@ -100,7 +100,7 @@ The authors instead aim for a solution that places files sensibly in the first p
 
 ### Cylinder Groups and understanding CHS
 
-The BSD FFS understands the physical layout of a harddisk, with cylinders, heads and sectors (CHS).
+The BSD FFS understands the physical layout of a harddisk, with [cylinders, heads and sectors](https://en.wikipedia.org/wiki/Cylinder-head-sector) (CHS).
 It divides the disk into cylinder groups, adjacent tracks of all disk heads.
 
 ![](/uploads/2023/05/cylinder-groups.png)


### PR DESCRIPTION
Add link to Wikipedia's discussion of CHS. 

At one point in the distant past I remembered what all that stuff was, but it has been reclaimed for other purposes.  The link was a good refresher and allowed me to enjoy your post more. Thank you for writing it.

I made this comment on HN, which you might find amusing:

>  I was at UCB during this time. Very exciting! Here's a story people may not know:
>
> The dump program, once the FFS was deployed, had not been modified to backup the last fragment of a file (because it was smaller, possibly than 4k). There was a disk crash on the VAX with the BSD source code and the disk company (Ampex, I think) came out and meticulously scrapped the bits off the disk, so CSRG could recovered the source code. There was no complete backup of it anywhere else.