### PR TITLE
Add missing userid in systemctl enable command

### DIFF
--- a/content/posts/2023-07-12-ubuntu-systemctl-user-does-not-work.md
+++ b/content/posts/2023-07-12-ubuntu-systemctl-user-does-not-work.md
@@ -75,7 +75,7 @@ The variable definitions must appear before the `case` statement, as shown.
 The user-based `systemd` component was not enabled and started.
 
 ```bash
-# systemctl enable user@.service
+# systemctl enable user@1011.service
 # systemctl start user@1011.service    # the userid of the user I needed
 ```
 


### PR DESCRIPTION
Another option would be to merge both commands into `systemctl enable --now user@1011.service`  (less typing, but maybe also less obvious/understandable for a blog article)