### PR TITLE
Restic: typo fixes

### DIFF
--- a/content/posts/2023-12-30-restic.md
+++ b/content/posts/2023-12-30-restic.md
@@ -216,7 +216,7 @@ Weil ich xfs verwendet und das versehentliches doppeltes Mounten eines Verzeichn
 muss ich dies mit der Option `nouuid` tun.
 
 Ich kann jetzt das `restic backup`-Kommando laufen lassen.
-Dies erfolgt unter anderem mit der Option `--json` und wir fischen den `summary`-Blog am Ende raus,
+Dies erfolgt unter anderem mit der Option `--json` und wir fischen den `summary`-Block am Ende raus,
 ohne die Progress Reports weiter zu beachten.
 
 Die Option `--exclude-caches` tut genau das:
@@ -475,7 +475,7 @@ aliases.db
 Die Sicherung vom (als kompromittiert anzusehenden) Minecraft-Server nach Hause muss passend gesichert werden.
 
 - Wir legen einen `resticuser` nur für die Sicherung dieses Servers an.
-- Er wird n der `/etc/ssh/sshd_config` auf `sftp-internal` constrained.
+- Er wird in der `/etc/ssh/sshd_config` auf `sftp-internal` constrained.
 - Der `.ssh/authorized_keys` dieses Users wird hinterlegt, 
   und als unveränderlich markiert, um Manipulationen zu erschweren.
 - Der `sftp`-User bekommt ein `chroot(2)` ins Datenverzeichnis und kann nicht auf sein eigenes Home zugreifen.


### PR DESCRIPTION
Noch ein kleiner Verbesserungsvorschlag:

Die Ausgabe von `ls -F ids/` beim FUSE-mount ist begrenzt hilfreich - woher soll man wissen, welche ID zu welchem Backupdatum gehört? Da wäre `ls -lF ids/` wohl hilfreicher (ich vermute mal, dass der Verzeichnis-Timestamp den Zeitpunkt des Backups anzeigt).