### PR TITLE
Don't call Flutter a Javascript-Framework (small fix)

### DIFF
--- a/content/posts/2024-07-12-sonos-s2-analysis.md
+++ b/content/posts/2024-07-12-sonos-s2-analysis.md
@@ -34,7 +34,7 @@ Das war anstrengend, um neue Features zu realisieren,
 weil es effektiv viermal gemacht werden mußte (Windows Desktop, Mac Desktop, Android und Mac Phone),
 aber es war sehr performant.
 
-Die neue App verwendet ein Javascript Framework für die Implementierung (angeblich Flutter).
+Die neue App verwendet ein Multiplattform-Framework für die Implementierung (angeblich Flutter).
 Sie ist Mobile only und verwendet mDNS, um Geräte zu finden.
 Das scheint weitaus weniger zuverlässig zu funktionieren, als SSDP.
 


### PR DESCRIPTION
Flutter was a JavaScript-Framework initially, but is not anymore. On mobile platforms like here it will compile to native machine code.