### PR TITLE
Update 2023-09-15-sshpass.md  homebrews readded sshpass

### DIFF
--- a/content/posts/2023-09-15-sshpass.md
+++ b/content/posts/2023-09-15-sshpass.md
@@ -27,7 +27,7 @@ erklärt:
 Warum der Artikel jetzt nach und vor diesem Satz dann erklärt,
 wie man das *benutzt*, statt zu zeigen, warum man das *nie braucht* und *wie man es ersetzt* ist unklar.
 
-Aber Homebrew ist hilfreich:
+Aber Homebrew ~~ist~~ war hilfreich:
 
 ```console
 $ brew search sshpass
@@ -38,7 +38,9 @@ If you meant "sshpass" specifically:
 We won't add sshpass because it makes it too easy for novice SSH users to ruin SSH's security.
 ```
 
-Das fasst es in etwa zusammen.
+Das fasst es in etwa zusammen, was Homebrew nicht daran hinderte, sshpass wieder aus der Blacklist zu entfernen:
+https://github.com/Homebrew/brew/pull/15979
+
 Okay, einmal das ganze gitlab, alle `.gitlab-ci.yml`, alle Branches, nach `sshpass -p` suchen.
 
 ## Es wird schlimmer


### PR DESCRIPTION

Mittlerweile (siehe https://github.com/Homebrew/brew/pull/15979 ) lässt Homebrew sshpass wieder zu ): Kann man sicher auch besser formulieren, als ich das gemacht habe