### PR TITLE
2024-07-16-energy: Tesla driving example, explicitly mention 11kW.

### DIFF
--- a/content/posts/2024-07-16-energy.md
+++ b/content/posts/2024-07-16-energy.md
@@ -95,7 +95,7 @@ Since charging slows down as the battery fills up, it will take approximately 4 
 You could get a 3 phase, 32 A connection, for a 22 kW charge-point.
 But the electricity company will charge you a lot more for that,
 and it is kind of pointless.
-Even a 100 kWh Tesla battery will charge from 10% to 80% in 6.5 h,
+Already at 11kW, even a 100 kWh Tesla battery will charge from 10% to 80% in 6.5 h,
 and you do not have to drive the battery to empty before you charge.
 
 In fact, if you charge every evening, just because you can, you are going to replace what you used up this day.


### PR DESCRIPTION
Example why 22kW charging makes no sense should explicitly mention that the calculation to charge a 100kWh tesla in 6.5h assumes 11kW.