### PR TITLE
Fix markdown link to Immich website

### DIFF
--- a/content/posts/2024-10-14-immich.md
+++ b/content/posts/2024-10-14-immich.md
@@ -9,7 +9,7 @@ tags:
 title: "Immich"
 ---
 
-[Immich]([url](https://immich.app)) is a web application for self-hosting that emulates the Google Photos interface on the web,
+[Immich](https://immich.app) is a web application for self-hosting that emulates the Google Photos interface on the web,
 and that has Android and iOS Cellphone applications for automatic upload and photo management.
 It also features metadata storage, machine learning for face recognition and object labeling.
 


### PR DESCRIPTION
Wrong markdown syntax for the link lead to the link being wrong: `https://blog.koehntopp.info/2024/10/14/[url]%28https://immich.app%29`